### PR TITLE
Add missing dependencies in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,9 @@ setup(
         'scipy',
         'patsy',
         'plotnine',
-        'twine'
+        'twine',
+        'joblib',
+        'drdid @ git+https://github.com/d2cml-ai/DRDID'
   ],
   packages=find_packages(),
   package_data={


### PR DESCRIPTION
When installing the package the `joblib` and `DRDID` packages are missing.
I have included them in the `setup.py` and also forcing the `DRDID` package to be installed from the github repo while the pypi package is out of date.

## Log
```txt
~/gh/di/did-tests                                                          did-tests
❯ python -m pip list
Package Version
------- -------
pip     24.2
❯ pip install git+https://github.com/d2cml-ai/csdid/
Collecting git+https://github.com/d2cml-ai/csdid/
  Cloning https://github.com/d2cml-ai/csdid/ to /tmp/pip-req-build-jniphjlc
  Running command git clone --filter=blob:none --quiet https://github.com/d2cml-ai/csdid/ /tmp/pip-req-build-jniphjlc
  Resolved https://github.com/d2cml-ai/csdid/ to commit 792132bb1202361a993681f904029235d063bb00
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting pandas (from csdid==0.2.6)
  Using cached pandas-2.2.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (89 kB)
Collecting numpy<=1.24.3 (from csdid==0.2.6)
  Using cached numpy-1.24.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (5.6 kB)
Collecting scipy (from csdid==0.2.6)
  Using cached scipy-1.14.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (60 kB)
Collecting patsy (from csdid==0.2.6)
  Using cached patsy-0.5.6-py2.py3-none-any.whl.metadata (3.5 kB)
Collecting plotnine (from csdid==0.2.6)
  Using cached plotnine-0.13.6-py3-none-any.whl.metadata (8.9 kB)
Collecting twine (from csdid==0.2.6)
  Using cached twine-5.1.1-py3-none-any.whl.metadata (3.5 kB)
Collecting python-dateutil>=2.8.2 (from pandas->csdid==0.2.6)
  Using cached python_dateutil-2.9.0.post0-py2.py3-none-any.whl.metadata (8.4 kB)
Collecting pytz>=2020.1 (from pandas->csdid==0.2.6)
  Using cached pytz-2024.2-py2.py3-none-any.whl.metadata (22 kB)
Collecting tzdata>=2022.7 (from pandas->csdid==0.2.6)
  Using cached tzdata-2024.2-py2.py3-none-any.whl.metadata (1.4 kB)
Collecting six (from patsy->csdid==0.2.6)
  Using cached six-1.16.0-py2.py3-none-any.whl.metadata (1.8 kB)
Collecting matplotlib>=3.7.0 (from plotnine->csdid==0.2.6)
  Using cached matplotlib-3.9.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (11 kB)
Collecting mizani~=0.11.0 (from plotnine->csdid==0.2.6)
  Using cached mizani-0.11.4-py3-none-any.whl.metadata (4.8 kB)
Collecting statsmodels>=0.14.0 (from plotnine->csdid==0.2.6)
  Using cached statsmodels-0.14.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (9.2 kB)
Collecting pkginfo>=1.8.1 (from twine->csdid==0.2.6)
  Using cached pkginfo-1.11.2-py3-none-any.whl.metadata (11 kB)
Collecting readme-renderer>=35.0 (from twine->csdid==0.2.6)
  Using cached readme_renderer-44.0-py3-none-any.whl.metadata (2.8 kB)
Collecting requests>=2.20 (from twine->csdid==0.2.6)
  Using cached requests-2.32.3-py3-none-any.whl.metadata (4.6 kB)
Collecting requests-toolbelt!=0.9.0,>=0.8.0 (from twine->csdid==0.2.6)
  Using cached requests_toolbelt-1.0.0-py2.py3-none-any.whl.metadata (14 kB)
Collecting urllib3>=1.26.0 (from twine->csdid==0.2.6)
  Using cached urllib3-2.2.3-py3-none-any.whl.metadata (6.5 kB)
Collecting importlib-metadata>=3.6 (from twine->csdid==0.2.6)
  Using cached importlib_metadata-8.5.0-py3-none-any.whl.metadata (4.8 kB)
Collecting keyring>=15.1 (from twine->csdid==0.2.6)
  Using cached keyring-25.4.1-py3-none-any.whl.metadata (20 kB)
Collecting rfc3986>=1.4.0 (from twine->csdid==0.2.6)
  Using cached rfc3986-2.0.0-py2.py3-none-any.whl.metadata (6.6 kB)
Collecting rich>=12.0.0 (from twine->csdid==0.2.6)
  Using cached rich-13.9.2-py3-none-any.whl.metadata (18 kB)
Collecting pkginfo>=1.8.1 (from twine->csdid==0.2.6)
  Using cached pkginfo-1.10.0-py3-none-any.whl.metadata (11 kB)
Collecting zipp>=3.20 (from importlib-metadata>=3.6->twine->csdid==0.2.6)
  Using cached zipp-3.20.2-py3-none-any.whl.metadata (3.7 kB)
Collecting jaraco.classes (from keyring>=15.1->twine->csdid==0.2.6)
  Using cached jaraco.classes-3.4.0-py3-none-any.whl.metadata (2.6 kB)
Collecting jaraco.functools (from keyring>=15.1->twine->csdid==0.2.6)
  Using cached jaraco.functools-4.1.0-py3-none-any.whl.metadata (2.9 kB)
Collecting jaraco.context (from keyring>=15.1->twine->csdid==0.2.6)
  Using cached jaraco.context-6.0.1-py3-none-any.whl.metadata (4.1 kB)
Collecting SecretStorage>=3.2 (from keyring>=15.1->twine->csdid==0.2.6)
  Using cached SecretStorage-3.3.3-py3-none-any.whl.metadata (4.0 kB)
Collecting jeepney>=0.4.2 (from keyring>=15.1->twine->csdid==0.2.6)
  Using cached jeepney-0.8.0-py3-none-any.whl.metadata (1.3 kB)
Collecting contourpy>=1.0.1 (from matplotlib>=3.7.0->plotnine->csdid==0.2.6)
  Using cached contourpy-1.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (5.4 kB)
Collecting cycler>=0.10 (from matplotlib>=3.7.0->plotnine->csdid==0.2.6)
  Using cached cycler-0.12.1-py3-none-any.whl.metadata (3.8 kB)
Collecting fonttools>=4.22.0 (from matplotlib>=3.7.0->plotnine->csdid==0.2.6)
  Using cached fonttools-4.54.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (163 kB)
Collecting kiwisolver>=1.3.1 (from matplotlib>=3.7.0->plotnine->csdid==0.2.6)
  Using cached kiwisolver-1.4.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (6.3 kB)
Collecting packaging>=20.0 (from matplotlib>=3.7.0->plotnine->csdid==0.2.6)
  Using cached packaging-24.1-py3-none-any.whl.metadata (3.2 kB)
Collecting pillow>=8 (from matplotlib>=3.7.0->plotnine->csdid==0.2.6)
  Using cached pillow-10.4.0-cp311-cp311-manylinux_2_28_x86_64.whl.metadata (9.2 kB)
Collecting pyparsing>=2.3.1 (from matplotlib>=3.7.0->plotnine->csdid==0.2.6)
  Using cached pyparsing-3.1.4-py3-none-any.whl.metadata (5.1 kB)
Collecting nh3>=0.2.14 (from readme-renderer>=35.0->twine->csdid==0.2.6)
  Using cached nh3-0.2.18-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (1.7 kB)
Collecting docutils>=0.21.2 (from readme-renderer>=35.0->twine->csdid==0.2.6)
  Using cached docutils-0.21.2-py3-none-any.whl.metadata (2.8 kB)
Collecting Pygments>=2.5.1 (from readme-renderer>=35.0->twine->csdid==0.2.6)
  Using cached pygments-2.18.0-py3-none-any.whl.metadata (2.5 kB)
Collecting charset-normalizer<4,>=2 (from requests>=2.20->twine->csdid==0.2.6)
  Using cached charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (34 kB)
Collecting idna<4,>=2.5 (from requests>=2.20->twine->csdid==0.2.6)
  Using cached idna-3.10-py3-none-any.whl.metadata (10 kB)
Collecting certifi>=2017.4.17 (from requests>=2.20->twine->csdid==0.2.6)
  Using cached certifi-2024.8.30-py3-none-any.whl.metadata (2.2 kB)
Collecting markdown-it-py>=2.2.0 (from rich>=12.0.0->twine->csdid==0.2.6)
  Using cached markdown_it_py-3.0.0-py3-none-any.whl.metadata (6.9 kB)
Collecting mdurl~=0.1 (from markdown-it-py>=2.2.0->rich>=12.0.0->twine->csdid==0.2.6)
  Using cached mdurl-0.1.2-py3-none-any.whl.metadata (1.6 kB)
Collecting cryptography>=2.0 (from SecretStorage>=3.2->keyring>=15.1->twine->csdid==0.2.6)
  Using cached cryptography-43.0.1-cp39-abi3-manylinux_2_28_x86_64.whl.metadata (5.4 kB)
Collecting more-itertools (from jaraco.classes->keyring>=15.1->twine->csdid==0.2.6)
  Using cached more_itertools-10.5.0-py3-none-any.whl.metadata (36 kB)
Collecting backports.tarfile (from jaraco.context->keyring>=15.1->twine->csdid==0.2.6)
  Using cached backports.tarfile-1.2.0-py3-none-any.whl.metadata (2.0 kB)
Collecting cffi>=1.12 (from cryptography>=2.0->SecretStorage>=3.2->keyring>=15.1->twine->csdid==0.2.6)
  Using cached cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (1.5 kB)
Collecting pycparser (from cffi>=1.12->cryptography>=2.0->SecretStorage>=3.2->keyring>=15.1->twine->csdid==0.2.6)
  Using cached pycparser-2.22-py3-none-any.whl.metadata (943 bytes)
Using cached numpy-1.24.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (17.3 MB)
Using cached pandas-2.2.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (13.1 MB)
Using cached patsy-0.5.6-py2.py3-none-any.whl (233 kB)
Using cached plotnine-0.13.6-py3-none-any.whl (1.3 MB)
Using cached scipy-1.14.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (41.2 MB)
Using cached twine-5.1.1-py3-none-any.whl (38 kB)
Using cached importlib_metadata-8.5.0-py3-none-any.whl (26 kB)
Using cached keyring-25.4.1-py3-none-any.whl (38 kB)
Using cached matplotlib-3.9.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (8.3 MB)
Using cached mizani-0.11.4-py3-none-any.whl (127 kB)
Using cached pkginfo-1.10.0-py3-none-any.whl (30 kB)
Using cached python_dateutil-2.9.0.post0-py2.py3-none-any.whl (229 kB)
Using cached pytz-2024.2-py2.py3-none-any.whl (508 kB)
Using cached readme_renderer-44.0-py3-none-any.whl (13 kB)
Using cached requests-2.32.3-py3-none-any.whl (64 kB)
Using cached requests_toolbelt-1.0.0-py2.py3-none-any.whl (54 kB)
Using cached rfc3986-2.0.0-py2.py3-none-any.whl (31 kB)
Using cached rich-13.9.2-py3-none-any.whl (242 kB)
Using cached six-1.16.0-py2.py3-none-any.whl (11 kB)
Using cached statsmodels-0.14.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (10.8 MB)
Using cached tzdata-2024.2-py2.py3-none-any.whl (346 kB)
Using cached urllib3-2.2.3-py3-none-any.whl (126 kB)
Using cached certifi-2024.8.30-py3-none-any.whl (167 kB)
Using cached charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (142 kB)
Using cached contourpy-1.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (323 kB)
Using cached cycler-0.12.1-py3-none-any.whl (8.3 kB)
Using cached docutils-0.21.2-py3-none-any.whl (587 kB)
Using cached fonttools-4.54.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (4.9 MB)
Using cached idna-3.10-py3-none-any.whl (70 kB)
Using cached jeepney-0.8.0-py3-none-any.whl (48 kB)
Using cached kiwisolver-1.4.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (1.4 MB)
Using cached markdown_it_py-3.0.0-py3-none-any.whl (87 kB)
Using cached nh3-0.2.18-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (769 kB)
Using cached packaging-24.1-py3-none-any.whl (53 kB)
Using cached pillow-10.4.0-cp311-cp311-manylinux_2_28_x86_64.whl (4.5 MB)
Using cached pygments-2.18.0-py3-none-any.whl (1.2 MB)
Using cached pyparsing-3.1.4-py3-none-any.whl (104 kB)
Using cached SecretStorage-3.3.3-py3-none-any.whl (15 kB)
Using cached zipp-3.20.2-py3-none-any.whl (9.2 kB)
Using cached jaraco.classes-3.4.0-py3-none-any.whl (6.8 kB)
Using cached jaraco.context-6.0.1-py3-none-any.whl (6.8 kB)
Using cached jaraco.functools-4.1.0-py3-none-any.whl (10 kB)
Using cached cryptography-43.0.1-cp39-abi3-manylinux_2_28_x86_64.whl (4.0 MB)
Using cached mdurl-0.1.2-py3-none-any.whl (10.0 kB)
Using cached backports.tarfile-1.2.0-py3-none-any.whl (30 kB)
Using cached more_itertools-10.5.0-py3-none-any.whl (60 kB)
Using cached cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (467 kB)
Using cached pycparser-2.22-py3-none-any.whl (117 kB)
Building wheels for collected packages: csdid
  Building wheel for csdid (pyproject.toml) ... done
  Created wheel for csdid: filename=csdid-0.2.6-py3-none-any.whl size=22462 sha256=50c7a295afe633799baac03341b3bfc1cdc498aefac01e44fbdcdc0dd924b515
  Stored in directory: /tmp/pip-ephem-wheel-cache-vkf2nfdj/wheels/51/7d/a1/002d42b36e7288f418457a532a826f270294dee0aacad27de1
Successfully built csdid
Installing collected packages: pytz, nh3, zipp, urllib3, tzdata, six, rfc3986, pyparsing, Pygments, pycparser, pkginfo, pillow, packaging, numpy, more-itertools, mdurl, kiwisolver, jeepney, idna, fonttools, docutils, cycler, charset-normalizer, certifi, backports.tarfile, scipy, requests, readme-renderer, python-dateutil, patsy, markdown-it-py, jaraco.functools, jaraco.context, jaraco.classes, importlib-metadata, contourpy, cffi, rich, requests-toolbelt, pandas, matplotlib, cryptography, statsmodels, SecretStorage, mizani, plotnine, keyring, twine, csdid
Successfully installed Pygments-2.18.0 SecretStorage-3.3.3 backports.tarfile-1.2.0 certifi-2024.8.30 cffi-1.17.1 charset-normalizer-3.4.0 contourpy-1.3.0 cryptography-43.0.1 csdid-0.2.6 cycler-0.12.1 docutils-0.21.2 fonttools-4.54.1 idna-3.10 importlib-metadata-8.5.0 jaraco.classes-3.4.0 jaraco.context-6.0.1 jaraco.functools-4.1.0 jeepney-0.8.0 keyring-25.4.1 kiwisolver-1.4.7 markdown-it-py-3.0.0 matplotlib-3.9.2 mdurl-0.1.2 mizani-0.11.4 more-itertools-10.5.0 nh3-0.2.18 numpy-1.24.3 packaging-24.1 pandas-2.2.3 patsy-0.5.6 pillow-10.4.0 pkginfo-1.10.0 plotnine-0.13.6 pycparser-2.22 pyparsing-3.1.4 python-dateutil-2.9.0.post0 pytz-2024.2 readme-renderer-44.0 requests-2.32.3 requests-toolbelt-1.0.0 rfc3986-2.0.0 rich-13.9.2 scipy-1.14.1 six-1.16.0 statsmodels-0.14.4 twine-5.1.1 tzdata-2024.2 urllib3-2.2.3 zipp-3.20.2
❯ python example.py
Traceback (most recent call last):
  File "/home/jsr-p/gh-repos/did-repos/did-tests/example.py", line 5, in <module>
    from csdid.att_gt import ATTgt
  File "/home/jsr-p/gh-repos/did-repos/did-tests/.venv/lib/python3.11/site-packages/csdid/att_gt.py", line 2, in <module>
    from csdid.aggte_fnc.aggte import aggte as agg_te
  File "/home/jsr-p/gh-repos/did-repos/did-tests/.venv/lib/python3.11/site-packages/csdid/aggte_fnc/aggte.py", line 83, in <module>
    from csdid.aggte_fnc.compute_aggte import compute_aggte
  File "/home/jsr-p/gh-repos/did-repos/did-tests/.venv/lib/python3.11/site-packages/csdid/aggte_fnc/compute_aggte.py", line 7, in <module>
    from csdid.aggte_fnc.utils import get_agg_inf_func, get_se, wif, AGGTEobj
  File "/home/jsr-p/gh-repos/did-repos/did-tests/.venv/lib/python3.11/site-packages/csdid/aggte_fnc/utils.py", line 2, in <module>
    from csdid.utils.mboot import mboot
  File "/home/jsr-p/gh-repos/did-repos/did-tests/.venv/lib/python3.11/site-packages/csdid/utils/mboot.py", line 3, in <module>
    from joblib import Parallel, delayed
ModuleNotFoundError: No module named 'joblib'
❯ pip install joblib
Collecting joblib
  Using cached joblib-1.4.2-py3-none-any.whl.metadata (5.4 kB)
Using cached joblib-1.4.2-py3-none-any.whl (301 kB)
Installing collected packages: joblib
Successfully installed joblib-1.4.2
❯ python example.py
Traceback (most recent call last):
  File "/home/jsr-p/gh-repos/did-repos/did-tests/example.py", line 5, in <module>
    from csdid.att_gt import ATTgt
  File "/home/jsr-p/gh-repos/did-repos/did-tests/.venv/lib/python3.11/site-packages/csdid/att_gt.py", line 5, in <module>
    from csdid.attgt_fnc.compute_att_gt import compute_att_gt
  File "/home/jsr-p/gh-repos/did-repos/did-tests/.venv/lib/python3.11/site-packages/csdid/attgt_fnc/compute_att_gt.py", line 3, in <module>
    from drdid import drdid, reg_did, ipwd_did
ModuleNotFoundError: No module named 'drdid'
❯ pip install git+https://github.com/d2cml-ai/DRDID
Collecting git+https://github.com/d2cml-ai/DRDID
  Cloning https://github.com/d2cml-ai/DRDID to /tmp/pip-req-build-o8d70zs2
  Running command git clone --filter=blob:none --quiet https://github.com/d2cml-ai/DRDID /tmp/pip-req-build-o8d70zs2
  Resolved https://github.com/d2cml-ai/DRDID to commit 90776e21b5778cd95228e3fd31ca8d2d257d2608
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Requirement already satisfied: pandas in ./.venv/lib/python3.11/site-packages (from drdid==1.1.5) (2.2.3)
Requirement already satisfied: numpy<=1.24.3 in ./.venv/lib/python3.11/site-packages (from drdid==1.1.5) (1.24.3)
Requirement already satisfied: statsmodels in ./.venv/lib/python3.11/site-packages (from drdid==1.1.5) (0.14.4)
Requirement already satisfied: python-dateutil>=2.8.2 in ./.venv/lib/python3.11/site-packages (from pandas->drdid==1.1.5) (2.9.0.post0)
Requirement already satisfied: pytz>=2020.1 in ./.venv/lib/python3.11/site-packages (from pandas->drdid==1.1.5) (2024.2)
Requirement already satisfied: tzdata>=2022.7 in ./.venv/lib/python3.11/site-packages (from pandas->drdid==1.1.5) (2024.2)
Requirement already satisfied: scipy!=1.9.2,>=1.8 in ./.venv/lib/python3.11/site-packages (from statsmodels->drdid==1.1.5) (1.14.1)
Requirement already satisfied: patsy>=0.5.6 in ./.venv/lib/python3.11/site-packages (from statsmodels->drdid==1.1.5) (0.5.6)
Requirement already satisfied: packaging>=21.3 in ./.venv/lib/python3.11/site-packages (from statsmodels->drdid==1.1.5) (24.1)
Requirement already satisfied: six in ./.venv/lib/python3.11/site-packages (from patsy>=0.5.6->statsmodels->drdid==1.1.5) (1.16.0)
Building wheels for collected packages: drdid
  Building wheel for drdid (pyproject.toml) ... done
  Created wheel for drdid: filename=drdid-1.1.5-py3-none-any.whl size=9530 sha256=68ce4b621eb359f05abc6f4c0e6cd70863e266fba3a9d54c84fa5b6135f55eb8
  Stored in directory: /tmp/pip-ephem-wheel-cache-0z2z4jk3/wheels/bd/21/1a/b47917442e9a4973a8f55ba05fff84a33641f5ae20fede75db
Successfully built drdid
Installing collected packages: drdid
Successfully installed drdid-1.1.5
❯ python example.py
    Group  Time  ATT(g, t)  Post  Std. Error  [95% Pointwise  Conf. Band]
0    2004  2004    -0.0105     0      0.0238         -0.0742       0.0532
1    2004  2005    -0.0704     0      0.0300         -0.1508       0.0099
2    2004  2006    -0.1373     0      0.0394         -0.2428      -0.0318  *
3    2004  2007    -0.1008     0      0.0361         -0.1975      -0.0041  *
4    2006  2004     0.0065     0      0.0235         -0.0564       0.0695
5    2006  2005    -0.0028     0      0.0203         -0.0571       0.0516
6    2006  2006    -0.0046     0      0.0180         -0.0529       0.0437
7    2006  2007    -0.0412     0      0.0215         -0.0988       0.0163
8    2007  2004     0.0305     0      0.0151         -0.0098       0.0708
9    2007  2005    -0.0027     0      0.0168         -0.0477       0.0423
10   2007  2006    -0.0311     0      0.0188         -0.0814       0.0192
11   2007  2007    -0.0261     0      0.0172         -0.0722       0.0201


Overall summary of ATT's based on calendar time aggregation:
    ATT Std. Error  [95.0%  Conf. Int.]
-0.0417     0.0169 -0.0747      -0.0087 *


Time Effects (calendar):
   Time  Estimate  Std. Error  [95.0% Simult.   Conf. Band
0  2004   -0.0105      0.0240          -0.0575      0.0365
1  2005   -0.0704      0.0323          -0.1337     -0.0071  *
2  2006   -0.0488      0.0218          -0.0916     -0.0061  *
3  2007   -0.0371      0.0138          -0.0641     -0.0100  *
---
Signif. codes: `*' confidence band does not cover 0
Control Group:  Never Treated ,
Anticipation Periods:  0
Estimation Method:  Doubly Robust


<csdid.att_gt.ATTgt object at 0x7365966375d0>
/home/jsr-p/gh-repos/did-repos/did-tests/.venv/lib/python3.11/site-packages/csdid/plots/gplot.py:19: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise in a future error of pandas. Value '['2004' '2005' '2006' '2007']' has dtype incompatible with int64, please explicitly cast to a compatible dtype first.
  ssresults.loc[:, 'year'] = ssresults['year'].astype(int).astype(str)
/home/jsr-p/gh-repos/did-repos/did-tests/.venv/lib/python3.11/site-packages/csdid/plots/gplot.py:19: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise in a future error of pandas. Value '['2004' '2005' '2006' '2007']' has dtype incompatible with int64, please explicitly cast to a compatible dtype first.
  ssresults.loc[:, 'year'] = ssresults['year'].astype(int).astype(str)
/home/jsr-p/gh-repos/did-repos/did-tests/.venv/lib/python3.11/site-packages/csdid/plots/gplot.py:19: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise in a future error of pandas. Value '['2004' '2005' '2006' '2007']' has dtype incompatible with int64, please explicitly cast to a compatible dtype first.
  ssresults.loc[:, 'year'] = ssresults['year'].astype(int).astype(str)
/home/jsr-p/gh-repos/did-repos/did-tests/.venv/lib/python3.11/site-packages/csdid/plots/gplot.py:19: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise in a future error of pandas. Value '['2004' '2005' '2006' '2007']' has dtype incompatible with int64, please explicitly cast to a compatible dtype first.
  ssresults.loc[:, 'year'] = ssresults['year'].astype(int).astype(str)
```
