### PR TITLE
ci: fix README workflow (push to protected main) + document PyPI trusted publishing

### DIFF
--- a/.github/workflows/gen_readme.yml
+++ b/.github/workflows/gen_readme.yml
@@ -4,16 +4,19 @@ on:
   push:
     branches:
       - main
-    # - cron: "40 15 * * 1,3,5"
+  workflow_dispatch:
 
 jobs:
   CreateQuarto:
-    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
+      # `contents: write` lets the action create the branch; `pull-requests: write`
+      # lets it open the PR. We no longer push to `main` directly because `main`
+      # is a protected branch (direct pushes are rejected with GH006).
       contents: write
+      pull-requests: write
     steps:
-      - name: Chequear el  código
+      - name: Chequear el código
         uses: actions/checkout@v4
 
       - name: Set up Quarto
@@ -24,22 +27,31 @@ jobs:
         with:
           python-version: "3.10"
           cache: "pip"
-      - run: pip uninstall csdid; pip install git+https://github.com/d2cml-ai/csdid/; pip install nbclient nbformat PyYAML; pip install git+https://github.com/d2cml-ai/DRDID
-      - name: Install Dependencies
-        run: pip install -r requirements.txt
+
+      - name: Install csdid and dependencies
+        run: |
+          pip uninstall -y csdid || true
+          pip install git+https://github.com/d2cml-ai/csdid/
+          pip install nbclient nbformat PyYAML
+          pip install git+https://github.com/d2cml-ai/DRDID
+          pip install -r requirements.txt
 
       - name: Generar quarto doc
         run: quarto render README.qmd
 
-      - id: commit
-        name: Commit  files
-        run: |
-          git config --local user.name "action-user"
-          git pull
-          git config --local user.email "actions@github.com"
-          git add -A
-          git commit -m "Update Readme"
-          git push origin main
-        env:
-          REPO_KEY: ${{ secrets.GITHUB_TOKEN }}
-          username: github-actions
+      - name: Open a PR with the regenerated README
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "docs: update generated README"
+          title: "docs: update generated README"
+          body: |
+            Automated regeneration of `readme.md` from `README.qmd` by the
+            **Actualizar Readme** workflow.
+
+            Merge this PR to publish the updated README. If there are no changes
+            to the rendered README, no PR is created.
+          branch: auto/update-readme
+          delete-branch: true
+          author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+          committer: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"


### PR DESCRIPTION
## Problem

Two workflows fail on every push to `main`:

1. **Actualizar Readme** → `git push origin main` is rejected:
   ```
   remote: error: GH006: Protected branch update failed for refs/heads/main.
   remote: - Changes must be made through a pull request.
   ```
   `main` is a protected branch, so the workflow can't push directly.

2. **Publish to PyPI** → Trusted Publishing exchange fails:
   ```
   * `invalid-publisher`: valid token, but no corresponding publisher
   ```
   No trusted publisher is registered on PyPI for `d2cml-ai/csdid` + `pypi.yml`,
   and there is no `PYPI_API_TOKEN` secret. **This is a PyPI-side configuration
   step (see below) — no code change can fix it.**

## This PR fixes #1 (the README workflow)

- Replaces the direct `git push origin main` with
  [`peter-evans/create-pull-request`](https://github.com/peter-evans/create-pull-request),
  so the regenerated `readme.md` is proposed via a PR that respects branch
  protection. No PR is opened when the rendered README is unchanged.
- Adds `pull-requests: write` permission (needed to open the PR).
- Makes the install step robust: `pip uninstall -y csdid || true`.
- Adds a `workflow_dispatch` trigger for manual runs.

The repo already has *Settings → Actions → "Allow GitHub Actions to create and
approve pull requests"* enabled, so no settings change is required.

## Remaining manual step for #2 (PyPI Trusted Publishing)

On https://pypi.org → project **csdid** → *Manage → Publishing → Add a new
publisher (GitHub)*:

| Field | Value |
|---|---|
| Owner | `d2cml-ai` |
| Repository name | `csdid` |
| Workflow name | `pypi.yml` |
| Environment name | *(leave blank)* |

Once saved, the existing `pypi.yml` (already configured for OIDC) will publish
successfully on the next version bump. `skip-existing: true` means runs without a
version bump just skip and succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)